### PR TITLE
Allow second argument in select to be undefined

### DIFF
--- a/modules/store/src/store.ts
+++ b/modules/store/src/store.ts
@@ -117,7 +117,7 @@ export function select<T, Props, K>(
 ): (source$: Observable<T>) => Observable<K>;
 export function select<T, a extends keyof T>(
   key: a,
-  props: null
+  props?: null
 ): (source$: Observable<T>) => Observable<T[a]>;
 export function select<T, a extends keyof T, b extends keyof T[a]>(
   key1: a,


### PR DESCRIPTION
fix(store): fix typing for select operator

Fix an issue where, if you do not supply a second argument to "select", you will get a result typed as "any". This is a regression introduced by https://github.com/ngrx/platform/commit/53832a154aae2f5e23e5afee8f79710ffd7b54de. As an example, in https://github.com/ngrx/platform/blob/8110c32e495dc2ee5fa56582b98cde8e5ee3b951/modules/store/spec/edge.spec.ts#L41 this line would previously have produced a result of the any type, but now produces an "Todo[]" typed object.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngrx/platform/blob/master/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
Typing fix
```

## What is the current behavior?
Supplying a single argument of type string to the `select` operator will produce a result of type `any`

Closes #

## What is the new behavior?
Supplying a single argument of type string to the `select` operator will produce a correctly typed result

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
